### PR TITLE
Fix: Prevent double browser open in OAuth2 flow

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -462,8 +462,7 @@ class Trader:
         # import urllib.parse # Already imported at top level
         auth_url_with_params = f"{auth_url}?{urllib.parse.urlencode(params)}"
 
-        print(f"Redirecting to browser for authentication: {auth_url_with_params}")
-        webbrowser.open(auth_url_with_params)
+        # webbrowser.open(auth_url_with_params) # Removed duplicate call - should open AFTER server starts
 
         # At this point, the application will wait. The user needs to authenticate
         # in the browser, and then manually provide the authorization code.


### PR DESCRIPTION
- Removed a duplicate call to webbrowser.open() during the OAuth2 authorization code flow initiation.
- Ensures the browser is opened only once after the local HTTP server is successfully started.

This commit amends the previous work on implementing the full OAuth2 authorization code flow, including token persistence and refresh.