### PR TITLE
Fix: Revert to standard OAuth URL and correct parameters

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
         "client_secret": "5nT43rQRm9IbUv1ELUbymjyTxbfIcsGECULNysuHrrJWji2zvz",
         "host_type": "demo",
         "default_ctid_trader_account_id": 6077021,
-        "spotware_auth_url": "https://id.ctrader.com/my/settings/openapi/grantingaccess/",
+        "spotware_auth_url": "https://connect.spotware.com/oauth/v2/auth",
         "spotware_token_url": "https://connect.spotware.com/oauth/v2/token",
         "redirect_uri": "http://localhost:5000/callback"
     },

--- a/settings.py
+++ b/settings.py
@@ -19,8 +19,8 @@ class OpenAPISettings:
     default_ctid_trader_account_id: Optional[int] = None # Store as int if it's numeric
 
     # OAuth2 specific URLs
-    spotware_auth_url: str = "https://id.ctrader.com/my/settings/openapi/grantingaccess/" # Updated URL
-    spotware_token_url: str = "https://connect.spotware.com/oauth/v2/token" # Assuming token URL remains standard
+    spotware_auth_url: str = "https://connect.spotware.com/oauth/v2/auth" # Standard URL
+    spotware_token_url: str = "https://connect.spotware.com/oauth/v2/token" # Standard URL
     redirect_uri: str = "http://localhost:5000/callback" # As specified
 
 
@@ -68,7 +68,7 @@ class Settings:
             client_secret=client_secret,
             host_type=openapi_cfg.get("host_type", "demo").lower(), # Ensure lowercase "demo" or "live"
             default_ctid_trader_account_id=openapi_cfg.get("default_ctid_trader_account_id"),
-            spotware_auth_url=openapi_cfg.get("spotware_auth_url", "https://id.ctrader.com/my/settings/openapi/grantingaccess/"), # Updated default
+            spotware_auth_url=openapi_cfg.get("spotware_auth_url", "https://connect.spotware.com/oauth/v2/auth"), # Standard default
             spotware_token_url=openapi_cfg.get("spotware_token_url", "https://connect.spotware.com/oauth/v2/token"),
             redirect_uri=openapi_cfg.get("redirect_uri", "http://localhost:5000/callback") # Should generally not be overridden from config
         )

--- a/trading.py
+++ b/trading.py
@@ -452,22 +452,15 @@ class Trader:
         scopes = "trading accounts" # Common scopes, adjust as needed
 
         # Construct the authorization URL using the new Spotware URL
-        # and add product=web parameter.
+        # Construct the authorization URL using the standard Spotware OAuth endpoint.
         params = {
+            "response_type": "code", # Required for Authorization Code flow
             "client_id": client_id,
             "redirect_uri": redirect_uri,
-            "scope": scopes,
-            "product": "web"
+            "scope": scopes
+            # product="web" is removed as it's not part of standard OAuth params here
+            # "state": "YOUR_UNIQUE_STATE_HERE" # Optional: for CSRF protection
         }
-        # For the "grantingaccess" URL, response_type=code might not be needed as a query parameter,
-        # as the URL's purpose itself is to grant access and then redirect with a code.
-        # However, if the standard token endpoint is used later, it expects a code from such a flow.
-        # If issues persist, we might test removing response_type=code for this specific auth_url.
-        # For now, let's assume it might still be implicitly part of the flow or handled by Spotware.
-        # If their example URL doesn't show response_type, we might remove it.
-        # The provided example "https://id.ctrader.com/my/settings/openapi/grantingaccess/?client_id={clientId}&redirect_uri={your_redirectURI}&scope={scope}&product=web"
-        # does not explicitly show response_type=code. Let's match that.
-
         auth_url_with_params = f"{auth_url}?{urllib.parse.urlencode(params)}"
 
         # At this point, the application will wait. The user needs to authenticate


### PR DESCRIPTION
- Reverted spotware_auth_url to 'https://connect.spotware.com/oauth/v2/auth'.
- Ensured 'response_type=code' is included in the authorization request params.
- Removed 'product=web' parameter from authorization request params.
- This aligns with the standard OAuth flow documented by Spotware and aims to resolve the '400 Bad Request' error during OAuth initiation.

## Summary by Sourcery

Bug Fixes:
- Align authorization flow with Spotware's standard OAuth by reverting to the connect endpoint, including response_type=code, and removing the product=web parameter.