### PR TITLE
Fix: Change OAuth scope to 'accounts'

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -449,7 +449,7 @@ class Trader:
         client_id = self.settings.openapi.client_id
         redirect_uri = self.settings.openapi.redirect_uri
         # Define scopes - this might need adjustment based on Spotware's requirements
-        scopes = "trading accounts" # Common scopes, adjust as needed
+        scopes = "accounts" # Changed from "trading accounts" to just "accounts" based on OpenApiPy example hint
 
         # Construct the authorization URL using the new Spotware URL
         # Construct the authorization URL using the standard Spotware OAuth endpoint.


### PR DESCRIPTION
- Modified the OAuth authorization request to request only the 'accounts' scope instead of 'trading accounts'.
- This change is based on hints from the spotware/OpenApiPy library examples and aims to resolve the '400 Bad Request' error by requesting a more fundamental and potentially more permissible scope.