### PR TITLE
Fix: Correct import location for ProtoOAPayloadType

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -69,7 +69,8 @@ try:
     from ctrader_open_api.messages.OpenApiCommonMessages_pb2 import (
         ProtoHeartbeatEvent,
         ProtoErrorRes,
-        ProtoMessage
+        ProtoMessage,
+        ProtoOAPayloadType # Moved from OpenApiMessages_pb2
     )
     from ctrader_open_api.messages.OpenApiMessages_pb2 import (
         ProtoOAApplicationAuthReq, ProtoOAApplicationAuthRes,
@@ -82,8 +83,8 @@ try:
         ProtoOAErrorRes,
         # For deserializing specific messages from ProtoMessage wrapper
         ProtoOAGetCtidProfileByTokenRes,
-        ProtoOAGetCtidProfileByTokenReq, # Added for sending
-        ProtoOAPayloadType
+        ProtoOAGetCtidProfileByTokenReq # Added for sending
+        # ProtoOAPayloadType was moved to OpenApiCommonMessages_pb2
     )
     from ctrader_open_api.messages.OpenApiModelMessages_pb2 import ProtoOATrader
     USE_OPENAPI_LIB = True


### PR DESCRIPTION
- Changed the import for ProtoOAPayloadType from OpenApiMessages_pb2 to OpenApiCommonMessages_pb2.
- This resolves an ImportError that caused the Trader to initialize in mock mode, preventing the OAuth flow and API connection from starting.

## Summary by Sourcery

Bug Fixes:
- Correct the import location of ProtoOAPayloadType from OpenApiMessages_pb2 to OpenApiCommonMessages_pb2 to prevent the Trader from initializing in mock mode and blocking the OAuth flow.