### PR TITLE
Debug: Attempt to access ProtoPayloadType as module attribute

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -66,11 +66,15 @@ import json # For token persistence
 # Imports from ctrader-open-api
 try:
     from ctrader_open_api import Client, TcpProtocol, EndPoints
+    # from ctrader_open_api.messages.OpenApiCommonMessages_pb2 import ProtoPayloadType # Keep this commented for now
+    from ctrader_open_api.messages import OpenApiCommonMessages_pb2 # Import the module
+    ProtoPayloadType = OpenApiCommonMessages_pb2.ProtoPayloadType # Try accessing as attribute
+
     from ctrader_open_api.messages.OpenApiCommonMessages_pb2 import (
         ProtoHeartbeatEvent,
         ProtoErrorRes,
-        ProtoMessage,
-        ProtoPayloadType # Corrected Enum name based on file content
+        ProtoMessage
+        # ProtoPayloadType removed from here for the test
     )
     from ctrader_open_api.messages.OpenApiMessages_pb2 import (
         ProtoOAApplicationAuthReq, ProtoOAApplicationAuthRes,


### PR DESCRIPTION
- Modified import logic to import OpenApiCommonMessages_pb2 module directly and then attempt to access ProtoPayloadType as an attribute.
- This is to diagnose if the enum exists but is not directly importable using 'from ... import ...' due to how it's defined or aliased in the generated protobuf Python file.
- Changed the main import exception handler to catch generic Exception to get more detailed error messages if attribute access fails.

## Summary by Sourcery

Change import strategy for the ProtoPayloadType enum to import the OpenApiCommonMessages_pb2 module directly and access the enum via attribute lookup, and broaden the import exception handler to catch generic Exceptions for improved debugging.

Bug Fixes:
- Broaden the import exception handler to catch generic Exception for more detailed error diagnostics

Enhancements:
- Import OpenApiCommonMessages_pb2 as a module and assign ProtoPayloadType via attribute access instead of direct import