### PR TITLE
Debug: Add prints to inspect ProtoOAPayloadType from OpenApiMessages_pb2

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -70,8 +70,10 @@ try:
         ProtoHeartbeatEvent,
         ProtoErrorRes,
         ProtoMessage
-        # ProtoPayloadType / ProtoOAPayloadType not here
     )
+    # Try importing ProtoOAPayloadType from OpenApiMessages_pb2
+    from ctrader_open_api.messages.OpenApiMessages_pb2 import ProtoOAPayloadType
+
     from ctrader_open_api.messages.OpenApiMessages_pb2 import (
         ProtoOAApplicationAuthReq, ProtoOAApplicationAuthRes,
         ProtoOAAccountAuthReq, ProtoOAAccountAuthRes,
@@ -81,12 +83,23 @@ try:
         ProtoOASpotEvent, ProtoOATraderUpdatedEvent,
         ProtoOANewOrderReq, ProtoOAExecutionEvent,
         ProtoOAErrorRes,
-        # Specific message types for deserialization
         ProtoOAGetCtidProfileByTokenRes,
         ProtoOAGetCtidProfileByTokenReq
     )
     from ctrader_open_api.messages.OpenApiModelMessages_pb2 import ProtoOATrader
     USE_OPENAPI_LIB = True
+    print("Successfully imported all required cTrader Open API messages and enums.")
+    # ---- DEBUG PRINTS START ----
+    try:
+        print(f"DEBUG: Type of ProtoOAPayloadType is: {type(ProtoOAPayloadType)}")
+        print(f"DEBUG: dir(ProtoOAPayloadType) is: {dir(ProtoOAPayloadType)}")
+        if hasattr(ProtoOAPayloadType, 'OA_APPLICATION_AUTH_RES'):
+            print(f"DEBUG: ProtoOAPayloadType.OA_APPLICATION_AUTH_RES exists. Value: {ProtoOAPayloadType.OA_APPLICATION_AUTH_RES}")
+        else:
+            print("DEBUG: ProtoOAPayloadType.OA_APPLICATION_AUTH_RES does NOT exist.")
+    except NameError:
+        print("DEBUG: ProtoOAPayloadType is not even defined at the point of debug prints (should not happen if import succeeded).")
+    # ---- DEBUG PRINTS END ----
 except ImportError as e:
     print(f"ctrader-open-api import failed ({e}); running in mock mode.")
     USE_OPENAPI_LIB = False


### PR DESCRIPTION
- Added debug print statements in trading.py immediately after imports to show the type and attributes of ProtoOAPayloadType imported from OpenApiMessages_pb2.py.
- This is to diagnose the NameError encountered in _on_message_received by understanding the actual structure of the imported ProtoOAPayloadType.

## Summary by Sourcery

Add runtime debug instrumentation in trading.py to inspect the ProtoOAPayloadType enum structure and diagnose import-related NameError issues.

Enhancements:
- Import ProtoOAPayloadType explicitly and log successful message imports.
- Add debug print statements to output the type, directory listing, and specific enum member existence for ProtoOAPayloadType within a try/except block.